### PR TITLE
Combined dependency updates (2025-08-28)

### DIFF
--- a/users/authservice/package-lock.json
+++ b/users/authservice/package-lock.json
@@ -13,7 +13,7 @@
                 "body-parser": "^2.2.0",
                 "express": "^5.1.0",
                 "jsonwebtoken": "^9.0.2",
-                "mongoose": "^8.17.1"
+                "mongoose": "^8.18.0"
             },
             "devDependencies": {
                 "jest": "^30.0.5",
@@ -4609,9 +4609,9 @@
             }
         },
         "node_modules/mongoose": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.17.1.tgz",
-            "integrity": "sha512-aodS4cacux5caoxB5ErEwRmrafIUsVRJxHnvP7URnSUnTenr32j1qBVV+KjYxryyLSisQkxglAFF69TNLeZTLg==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.18.0.tgz",
+            "integrity": "sha512-3TixPihQKBdyaYDeJqRjzgb86KbilEH07JmzV8SoSjgoskNTpa6oTBmDxeoF9p8YnWQoz7shnCyPkSV/48y3yw==",
             "license": "MIT",
             "dependencies": {
                 "bson": "^6.10.4",

--- a/users/authservice/package.json
+++ b/users/authservice/package.json
@@ -22,7 +22,7 @@
         "body-parser": "^2.2.0",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
-        "mongoose": "^8.17.1"
+        "mongoose": "^8.18.0"
     },
     "devDependencies": {
         "jest": "^30.0.5",

--- a/users/userservice/package-lock.json
+++ b/users/userservice/package-lock.json
@@ -12,7 +12,7 @@
         "bcrypt": "^6.0.0",
         "body-parser": "^2.2.0",
         "express": "^4.18.2",
-        "mongoose": "^8.17.1"
+        "mongoose": "^8.18.0"
       },
       "devDependencies": {
         "jest": "^30.0.5",
@@ -4654,9 +4654,9 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.17.1.tgz",
-      "integrity": "sha512-aodS4cacux5caoxB5ErEwRmrafIUsVRJxHnvP7URnSUnTenr32j1qBVV+KjYxryyLSisQkxglAFF69TNLeZTLg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.18.0.tgz",
+      "integrity": "sha512-3TixPihQKBdyaYDeJqRjzgb86KbilEH07JmzV8SoSjgoskNTpa6oTBmDxeoF9p8YnWQoz7shnCyPkSV/48y3yw==",
       "license": "MIT",
       "dependencies": {
         "bson": "^6.10.4",

--- a/users/userservice/package.json
+++ b/users/userservice/package.json
@@ -22,7 +22,7 @@
     "bcrypt": "^6.0.0",
     "body-parser": "^2.2.0",
     "express": "^4.18.2",
-    "mongoose": "^8.17.1"
+    "mongoose": "^8.18.0"
   },
   "devDependencies": {
     "jest": "^30.0.5",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -11,7 +11,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.11.0",
         "@mui/material": "^5.15.15",
-        "@testing-library/jest-dom": "^6.7.0",
+        "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
         "axios": "^1.6.8",
@@ -5420,9 +5420,9 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.7.0.tgz",
-      "integrity": "sha512-RI2e97YZ7MRa+vxP4UUnMuMFL2buSsf0ollxUbTgrbPLKhMn8KVTx7raS6DYjC7v1NDVrioOvaShxsguLNISCA==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.8.0.tgz",
+      "integrity": "sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==",
       "license": "MIT",
       "dependencies": {
         "@adobe/css-tools": "^4.4.0",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -16,7 +16,7 @@
         "@testing-library/user-event": "^14.6.1",
         "axios": "^1.6.8",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0",
+        "react-dom": "^19.1.1",
         "react-scripts": "5.0.1",
         "web-vitals": "^3.5.2"
       },
@@ -2595,28 +2595,31 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.1"
+        "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
-      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.0.0",
-        "@floating-ui/utils": "^0.2.0"
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
-      "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
+      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.6.1"
+        "@floating-ui/dom": "^1.7.4"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -2624,9 +2627,10 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
-      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
@@ -4556,37 +4560,6 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
-    "node_modules/@mui/base": {
-      "version": "5.0.0-beta.40",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.40.tgz",
-      "integrity": "sha512-I/lGHztkCzvwlXpjD2+SNmvNQvB4227xBXhISPjEaJUXGImOQ9f3D2Yj/T3KasSI/h0MLWy74X0J6clhPmsRbQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@floating-ui/react-dom": "^2.0.8",
-        "@mui/types": "^7.2.14",
-        "@mui/utils": "^5.15.14",
-        "@popperjs/core": "^2.11.8",
-        "clsx": "^2.1.0",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "5.15.15",
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.15.tgz",
@@ -4635,6 +4608,39 @@
         "@emotion/styled": {
           "optional": true
         },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material/node_modules/@mui/base": {
+      "version": "5.0.0-beta.40",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.40.tgz",
+      "integrity": "sha512-I/lGHztkCzvwlXpjD2+SNmvNQvB4227xBXhISPjEaJUXGImOQ9f3D2Yj/T3KasSI/h0MLWy74X0J6clhPmsRbQ==",
+      "deprecated": "This package has been replaced by @base-ui-components/react",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "@floating-ui/react-dom": "^2.0.8",
+        "@mui/types": "^7.2.14",
+        "@mui/utils": "^5.15.14",
+        "@popperjs/core": "^2.11.8",
+        "clsx": "^2.1.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
         "@types/react": {
           "optional": true
         }
@@ -4908,6 +4914,7 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -21984,15 +21991,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
+      "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
+      "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
+        "scheduler": "^0.26.0"
       },
       "peerDependencies": {
-        "react": "^18.2.0"
+        "react": "^19.1.1"
       }
     },
     "node_modules/react-error-overlay": {
@@ -24187,12 +24194,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "3.3.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -11,7 +11,7 @@
     "@testing-library/user-event": "^14.6.1",
     "axios": "^1.6.8",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react-dom": "^19.1.1",
     "react-scripts": "5.0.1",
     "web-vitals": "^3.5.2"
   },

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -6,7 +6,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.11.0",
     "@mui/material": "^5.15.15",
-    "@testing-library/jest-dom": "^6.7.0",
+    "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "axios": "^1.6.8",


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump mongoose from 8.17.1 to 8.18.0 in /users/authservice](https://github.com/augustocristian/asw2324_0/pull/147)
- [Bump react-dom from 18.2.0 to 19.1.1 in /webapp](https://github.com/augustocristian/asw2324_0/pull/146)
- [Bump @testing-library/jest-dom from 6.7.0 to 6.8.0 in /webapp](https://github.com/augustocristian/asw2324_0/pull/145)
- [Bump mongoose from 8.17.1 to 8.18.0 in /users/userservice](https://github.com/augustocristian/asw2324_0/pull/144)