### PR TITLE
Combined dependency updates (2025-09-13)

### DIFF
--- a/gatewayservice/package-lock.json
+++ b/gatewayservice/package-lock.json
@@ -15,22 +15,8 @@
                 "express-prom-bundle": "^7.0.0"
             },
             "devDependencies": {
-                "jest": "^30.1.2",
+                "jest": "^30.1.3",
                 "supertest": "^6.3.4"
-            }
-        },
-        "node_modules/@ampproject/remapping": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-            "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.24"
-            },
-            "engines": {
-                "node": ">=6.0.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -49,9 +35,9 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
-            "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
+            "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -59,22 +45,22 @@
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
-            "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
+            "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.3",
                 "@babel/helper-compilation-targets": "^7.27.2",
                 "@babel/helper-module-transforms": "^7.28.3",
-                "@babel/helpers": "^7.28.3",
-                "@babel/parser": "^7.28.3",
+                "@babel/helpers": "^7.28.4",
+                "@babel/parser": "^7.28.4",
                 "@babel/template": "^7.27.2",
-                "@babel/traverse": "^7.28.3",
-                "@babel/types": "^7.28.2",
+                "@babel/traverse": "^7.28.4",
+                "@babel/types": "^7.28.4",
+                "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -206,27 +192,27 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.3.tgz",
-            "integrity": "sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+            "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/template": "^7.27.2",
-                "@babel/types": "^7.28.2"
+                "@babel/types": "^7.28.4"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
-            "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+            "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.28.2"
+                "@babel/types": "^7.28.4"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -490,18 +476,18 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.3.tgz",
-            "integrity": "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+            "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.3",
                 "@babel/helper-globals": "^7.28.0",
-                "@babel/parser": "^7.28.3",
+                "@babel/parser": "^7.28.4",
                 "@babel/template": "^7.27.2",
-                "@babel/types": "^7.28.2",
+                "@babel/types": "^7.28.4",
                 "debug": "^4.3.1"
             },
             "engines": {
@@ -509,9 +495,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.28.2",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
-            "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+            "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -627,16 +613,16 @@
             }
         },
         "node_modules/@jest/core": {
-            "version": "30.1.2",
-            "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.1.2.tgz",
-            "integrity": "sha512-iSLOojkYgM7Lw0FF5egecZh+CiLWe4xICM3WOMjFbewhbWn+ixEoPwY7oK9jSCnLLphMFAjussXp7CE3tHa5EA==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.1.3.tgz",
+            "integrity": "sha512-LIQz7NEDDO1+eyOA2ZmkiAyYvZuo6s1UxD/e2IHldR6D7UYogVq3arTmli07MkENLq6/3JEQjp0mA8rrHHJ8KQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jest/console": "30.1.2",
                 "@jest/pattern": "30.0.1",
-                "@jest/reporters": "30.1.2",
-                "@jest/test-result": "30.1.2",
+                "@jest/reporters": "30.1.3",
+                "@jest/test-result": "30.1.3",
                 "@jest/transform": "30.1.2",
                 "@jest/types": "30.0.5",
                 "@types/node": "*",
@@ -646,18 +632,18 @@
                 "exit-x": "^0.2.2",
                 "graceful-fs": "^4.2.11",
                 "jest-changed-files": "30.0.5",
-                "jest-config": "30.1.2",
+                "jest-config": "30.1.3",
                 "jest-haste-map": "30.1.0",
                 "jest-message-util": "30.1.0",
                 "jest-regex-util": "30.0.1",
-                "jest-resolve": "30.1.0",
-                "jest-resolve-dependencies": "30.1.2",
-                "jest-runner": "30.1.2",
-                "jest-runtime": "30.1.2",
+                "jest-resolve": "30.1.3",
+                "jest-resolve-dependencies": "30.1.3",
+                "jest-runner": "30.1.3",
+                "jest-runtime": "30.1.3",
                 "jest-snapshot": "30.1.2",
                 "jest-util": "30.0.5",
                 "jest-validate": "30.1.0",
-                "jest-watcher": "30.1.2",
+                "jest-watcher": "30.1.3",
                 "micromatch": "^4.0.8",
                 "pretty-format": "30.0.5",
                 "slash": "^3.0.0"
@@ -786,15 +772,15 @@
             }
         },
         "node_modules/@jest/reporters": {
-            "version": "30.1.2",
-            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.1.2.tgz",
-            "integrity": "sha512-8Jd7y3DUFBn8dG/bNJ2blmaJmT2Up74WAXkUJsbL0OuEZHDRRMnS4JmRtLArW2d0H5k8RDdhNN7j70Ki16Zr5g==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.1.3.tgz",
+            "integrity": "sha512-VWEQmJWfXMOrzdFEOyGjUEOuVXllgZsoPtEHZzfdNz18RmzJ5nlR6kp8hDdY8dDS1yGOXAY7DHT+AOHIPSBV0w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@bcoe/v8-coverage": "^0.2.3",
                 "@jest/console": "30.1.2",
-                "@jest/test-result": "30.1.2",
+                "@jest/test-result": "30.1.3",
                 "@jest/transform": "30.1.2",
                 "@jest/types": "30.0.5",
                 "@jridgewell/trace-mapping": "^0.3.25",
@@ -873,9 +859,9 @@
             }
         },
         "node_modules/@jest/test-result": {
-            "version": "30.1.2",
-            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.1.2.tgz",
-            "integrity": "sha512-mpKFr8DEpfG5aAfQYA5+3KneAsRBXhF7zwtwqT4UeYBckoOPD1MzVxU6gDHwx4gRB7I1MKL6owyJzr8QRq402Q==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.1.3.tgz",
+            "integrity": "sha512-P9IV8T24D43cNRANPPokn7tZh0FAFnYS2HIfi5vK18CjRkTDR9Y3e1BoEcAJnl4ghZZF4Ecda4M/k41QkvurEQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -889,13 +875,13 @@
             }
         },
         "node_modules/@jest/test-sequencer": {
-            "version": "30.1.2",
-            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.1.2.tgz",
-            "integrity": "sha512-v3vawuj2LC0XjpzF4q0pI0ZlQvMBDNqfRZZ2yHqcsGt7JEYsDK2L1WwrybEGlnOaEvnDFML/Y9xWLiW47Dda8A==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.1.3.tgz",
+            "integrity": "sha512-82J+hzC0qeQIiiZDThh+YUadvshdBswi5nuyXlEmXzrhw5ZQSRHeQ5LpVMD/xc8B3wPePvs6VMzHnntxL+4E3w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/test-result": "30.1.2",
+                "@jest/test-result": "30.1.3",
                 "graceful-fs": "^4.2.11",
                 "jest-haste-map": "30.1.0",
                 "slash": "^3.0.0"
@@ -958,6 +944,17 @@
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/remapping": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.24"
             }
         },
@@ -1582,9 +1579,9 @@
             }
         },
         "node_modules/ansi-regex": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
-            "integrity": "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1685,11 +1682,14 @@
             }
         },
         "node_modules/babel-plugin-istanbul": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.0.tgz",
-            "integrity": "sha512-C5OzENSx/A+gt7t4VH1I2XsflxyPUmXRFPKBxt33xncdOmq7oROVM3bZv9Ysjjkv8OJYDMa+tKuKMvqU/H3xdw==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+            "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "workspaces": [
+                "test/babel-8"
+            ],
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "@istanbuljs/load-nyc-config": "^1.0.0",
@@ -1925,9 +1925,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001739",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001739.tgz",
-            "integrity": "sha512-y+j60d6ulelrNSwpPyrHdl+9mJnQzHBr08xm48Qno0nSk4h3Qojh+ziv2qE6rXf4k3tadF4o1J/1tAbVm1NtnA==",
+            "version": "1.0.30001741",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
+            "integrity": "sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==",
             "dev": true,
             "funding": [
                 {
@@ -2235,9 +2235,9 @@
             }
         },
         "node_modules/dedent": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
-            "integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
+            "integrity": "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
@@ -2333,9 +2333,9 @@
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.211",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.211.tgz",
-            "integrity": "sha512-IGBvimJkotaLzFnwIVgW9/UD/AOJ2tByUmeOrtqBfACSbAw5b1G0XpvdaieKyc7ULmbwXVx+4e4Be8pOPBrYkw==",
+            "version": "1.5.214",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.214.tgz",
+            "integrity": "sha512-TpvUNdha+X3ybfU78NoQatKvQEm1oq3lf2QbnmCEdw+Bd9RuIAY+hJTvq1avzHM0f7EJfnH3vbCnbzKzisc/9Q==",
             "dev": true,
             "license": "ISC"
         },
@@ -3540,16 +3540,16 @@
             }
         },
         "node_modules/jest": {
-            "version": "30.1.2",
-            "resolved": "https://registry.npmjs.org/jest/-/jest-30.1.2.tgz",
-            "integrity": "sha512-iLreJmUWdANLD2UIbebrXxQqU9jIxv2ahvrBNfff55deL9DtVxm8ZJBLk/kmn0AQ+FyCTrNSlGbMdTgSasldYA==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-30.1.3.tgz",
+            "integrity": "sha512-Ry+p2+NLk6u8Agh5yVqELfUJvRfV51hhVBRIB5yZPY7mU0DGBmOuFG5GebZbMbm86cdQNK0fhJuDX8/1YorISQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/core": "30.1.2",
+                "@jest/core": "30.1.3",
                 "@jest/types": "30.0.5",
                 "import-local": "^3.2.0",
-                "jest-cli": "30.1.2"
+                "jest-cli": "30.1.3"
             },
             "bin": {
                 "jest": "bin/jest.js"
@@ -3582,15 +3582,15 @@
             }
         },
         "node_modules/jest-circus": {
-            "version": "30.1.2",
-            "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.1.2.tgz",
-            "integrity": "sha512-pyqgRv00fPbU3QBjN9I5QRd77eCWA19NA7BLgI1veFvbUIFpeDCKbnG1oyRr6q5/jPEW2zDfqZ/r6fvfE85vrA==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.1.3.tgz",
+            "integrity": "sha512-Yf3dnhRON2GJT4RYzM89t/EXIWNxKTpWTL9BfF3+geFetWP4XSvJjiU1vrWplOiUkmq8cHLiwuhz+XuUp9DscA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jest/environment": "30.1.2",
                 "@jest/expect": "30.1.2",
-                "@jest/test-result": "30.1.2",
+                "@jest/test-result": "30.1.3",
                 "@jest/types": "30.0.5",
                 "@types/node": "*",
                 "chalk": "^4.1.2",
@@ -3600,7 +3600,7 @@
                 "jest-each": "30.1.0",
                 "jest-matcher-utils": "30.1.2",
                 "jest-message-util": "30.1.0",
-                "jest-runtime": "30.1.2",
+                "jest-runtime": "30.1.3",
                 "jest-snapshot": "30.1.2",
                 "jest-util": "30.0.5",
                 "p-limit": "^3.1.0",
@@ -3614,19 +3614,19 @@
             }
         },
         "node_modules/jest-cli": {
-            "version": "30.1.2",
-            "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.1.2.tgz",
-            "integrity": "sha512-Q7H6GGo/0TBB8Mhm3Ab7KKJHn6GeMVff+/8PVCQ7vXXahvr5sRERnNbxuVJAMiVY2JQm5roA7CHYOYlH+gzmUg==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.1.3.tgz",
+            "integrity": "sha512-G8E2Ol3OKch1DEeIBl41NP7OiC6LBhfg25Btv+idcusmoUSpqUkbrneMqbW9lVpI/rCKb/uETidb7DNteheuAQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/core": "30.1.2",
-                "@jest/test-result": "30.1.2",
+                "@jest/core": "30.1.3",
+                "@jest/test-result": "30.1.3",
                 "@jest/types": "30.0.5",
                 "chalk": "^4.1.2",
                 "exit-x": "^0.2.2",
                 "import-local": "^3.2.0",
-                "jest-config": "30.1.2",
+                "jest-config": "30.1.3",
                 "jest-util": "30.0.5",
                 "jest-validate": "30.1.0",
                 "yargs": "^17.7.2"
@@ -3647,16 +3647,16 @@
             }
         },
         "node_modules/jest-config": {
-            "version": "30.1.2",
-            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.1.2.tgz",
-            "integrity": "sha512-gCuBeE/cksjQ3e1a8H4YglZJuVPcnLZQK9jC70E6GbkHNQKPasnOO+r9IYdsUbAekb6c7eVRR8laGLMF06gMqg==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.1.3.tgz",
+            "integrity": "sha512-M/f7gqdQEPgZNA181Myz+GXCe8jXcJsGjCMXUzRj22FIXsZOyHNte84e0exntOvdPaeh9tA0w+B8qlP2fAezfw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.27.4",
                 "@jest/get-type": "30.1.0",
                 "@jest/pattern": "30.0.1",
-                "@jest/test-sequencer": "30.1.2",
+                "@jest/test-sequencer": "30.1.3",
                 "@jest/types": "30.0.5",
                 "babel-jest": "30.1.2",
                 "chalk": "^4.1.2",
@@ -3664,12 +3664,12 @@
                 "deepmerge": "^4.3.1",
                 "glob": "^10.3.10",
                 "graceful-fs": "^4.2.11",
-                "jest-circus": "30.1.2",
+                "jest-circus": "30.1.3",
                 "jest-docblock": "30.0.1",
                 "jest-environment-node": "30.1.2",
                 "jest-regex-util": "30.0.1",
-                "jest-resolve": "30.1.0",
-                "jest-runner": "30.1.2",
+                "jest-resolve": "30.1.3",
+                "jest-runner": "30.1.3",
                 "jest-util": "30.0.5",
                 "jest-validate": "30.1.0",
                 "micromatch": "^4.0.8",
@@ -3883,9 +3883,9 @@
             }
         },
         "node_modules/jest-resolve": {
-            "version": "30.1.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.1.0.tgz",
-            "integrity": "sha512-hASe7D/wRtZw8Cm607NrlF7fi3HWC5wmA5jCVc2QjQAB2pTwP9eVZILGEi6OeSLNUtE1zb04sXRowsdh5CUjwA==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.1.3.tgz",
+            "integrity": "sha512-DI4PtTqzw9GwELFS41sdMK32Ajp3XZQ8iygeDMWkxlRhm7uUTOFSZFVZABFuxr0jvspn8MAYy54NxZCsuCTSOw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3903,9 +3903,9 @@
             }
         },
         "node_modules/jest-resolve-dependencies": {
-            "version": "30.1.2",
-            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.1.2.tgz",
-            "integrity": "sha512-HJjyoaedY4wrwda+eqvgjbwFykrAnQEmhuT0bMyOV3GQIyLPcunZcjfkm77Zr11ujwl34ySdc4qYnm7SG75TjA==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.1.3.tgz",
+            "integrity": "sha512-DNfq3WGmuRyHRHfEet+Zm3QOmVFtIarUOQHHryKPc0YL9ROfgWZxl4+aZq/VAzok2SS3gZdniP+dO4zgo59hBg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3917,15 +3917,15 @@
             }
         },
         "node_modules/jest-runner": {
-            "version": "30.1.2",
-            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.1.2.tgz",
-            "integrity": "sha512-eu9AzpDY/QV+7NuMg6fZMpQ7M24cBkl5dyS1Xj7iwDPDriOmLUXR8rLojESibcIX+sCDTO4KvUeaxWCH1fbTvg==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.1.3.tgz",
+            "integrity": "sha512-dd1ORcxQraW44Uz029TtXj85W11yvLpDuIzNOlofrC8GN+SgDlgY4BvyxJiVeuabA1t6idjNbX59jLd2oplOGQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jest/console": "30.1.2",
                 "@jest/environment": "30.1.2",
-                "@jest/test-result": "30.1.2",
+                "@jest/test-result": "30.1.3",
                 "@jest/transform": "30.1.2",
                 "@jest/types": "30.0.5",
                 "@types/node": "*",
@@ -3938,10 +3938,10 @@
                 "jest-haste-map": "30.1.0",
                 "jest-leak-detector": "30.1.0",
                 "jest-message-util": "30.1.0",
-                "jest-resolve": "30.1.0",
-                "jest-runtime": "30.1.2",
+                "jest-resolve": "30.1.3",
+                "jest-runtime": "30.1.3",
                 "jest-util": "30.0.5",
-                "jest-watcher": "30.1.2",
+                "jest-watcher": "30.1.3",
                 "jest-worker": "30.1.0",
                 "p-limit": "^3.1.0",
                 "source-map-support": "0.5.13"
@@ -3951,9 +3951,9 @@
             }
         },
         "node_modules/jest-runtime": {
-            "version": "30.1.2",
-            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.1.2.tgz",
-            "integrity": "sha512-zU02si+lAITgyRmVRgJn/AB4cnakq8+o7bP+5Z+N1A4r2mq40zGbmrg3UpYQWCkeim17tx8w1Tnmt6tQ6y9PGA==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.1.3.tgz",
+            "integrity": "sha512-WS8xgjuNSphdIGnleQcJ3AKE4tBKOVP+tKhCD0u+Tb2sBmsU8DxfbBpZX7//+XOz81zVs4eFpJQwBNji2Y07DA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3961,7 +3961,7 @@
                 "@jest/fake-timers": "30.1.2",
                 "@jest/globals": "30.1.2",
                 "@jest/source-map": "30.0.1",
-                "@jest/test-result": "30.1.2",
+                "@jest/test-result": "30.1.3",
                 "@jest/transform": "30.1.2",
                 "@jest/types": "30.0.5",
                 "@types/node": "*",
@@ -3974,7 +3974,7 @@
                 "jest-message-util": "30.1.0",
                 "jest-mock": "30.0.5",
                 "jest-regex-util": "30.0.1",
-                "jest-resolve": "30.1.0",
+                "jest-resolve": "30.1.3",
                 "jest-snapshot": "30.1.2",
                 "jest-util": "30.0.5",
                 "slash": "^3.0.0",
@@ -4093,13 +4093,13 @@
             }
         },
         "node_modules/jest-watcher": {
-            "version": "30.1.2",
-            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.1.2.tgz",
-            "integrity": "sha512-MtoGuEgqsBM8Jkn52oEj+mXLtF94+njPlHI5ydfduZL5MHrTFr14ZG1CUX1xAbY23dbSZCCEkEPhBM3cQd12Jg==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.1.3.tgz",
+            "integrity": "sha512-6jQUZCP1BTL2gvG9E4YF06Ytq4yMb4If6YoQGRR6PpjtqOXSP3sKe2kqwB6SQ+H9DezOfZaSLnmka1NtGm3fCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/test-result": "30.1.2",
+                "@jest/test-result": "30.1.3",
                 "@jest/types": "30.0.5",
                 "@types/node": "*",
                 "ansi-escapes": "^4.3.2",
@@ -4450,9 +4450,9 @@
             "license": "MIT"
         },
         "node_modules/node-releases": {
-            "version": "2.0.19",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-            "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+            "version": "2.0.20",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.20.tgz",
+            "integrity": "sha512-7gK6zSXEH6neM212JgfYFXe+GmZQM+fia5SsusuBIUgnPheLFBmIPhtFoAQRj8/7wASYQnbDlHPVwY0BefoFgA==",
             "dev": true,
             "license": "MIT"
         },
@@ -5270,9 +5270,9 @@
             }
         },
         "node_modules/strip-ansi": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+            "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5844,9 +5844,9 @@
             }
         },
         "node_modules/wrap-ansi/node_modules/ansi-styles": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-            "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/gatewayservice/package.json
+++ b/gatewayservice/package.json
@@ -24,7 +24,7 @@
         "express-prom-bundle": "^7.0.0"
     },
     "devDependencies": {
-        "jest": "^30.1.2",
+        "jest": "^30.1.3",
         "supertest": "^6.3.4"
     }
 }

--- a/users/authservice/package-lock.json
+++ b/users/authservice/package-lock.json
@@ -16,23 +16,9 @@
                 "mongoose": "^8.18.0"
             },
             "devDependencies": {
-                "jest": "^30.1.2",
+                "jest": "^30.1.3",
                 "mongodb-memory-server": "^10.2.0",
                 "supertest": "^7.1.4"
-            }
-        },
-        "node_modules/@ampproject/remapping": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-            "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.24"
-            },
-            "engines": {
-                "node": ">=6.0.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -51,9 +37,9 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
-            "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
+            "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -61,22 +47,22 @@
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
-            "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
+            "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.3",
                 "@babel/helper-compilation-targets": "^7.27.2",
                 "@babel/helper-module-transforms": "^7.28.3",
-                "@babel/helpers": "^7.28.3",
-                "@babel/parser": "^7.28.3",
+                "@babel/helpers": "^7.28.4",
+                "@babel/parser": "^7.28.4",
                 "@babel/template": "^7.27.2",
-                "@babel/traverse": "^7.28.3",
-                "@babel/types": "^7.28.2",
+                "@babel/traverse": "^7.28.4",
+                "@babel/types": "^7.28.4",
+                "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -228,27 +214,27 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.3.tgz",
-            "integrity": "sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+            "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/template": "^7.27.2",
-                "@babel/types": "^7.28.2"
+                "@babel/types": "^7.28.4"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
-            "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+            "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.28.2"
+                "@babel/types": "^7.28.4"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -512,18 +498,18 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.3.tgz",
-            "integrity": "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+            "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.3",
                 "@babel/helper-globals": "^7.28.0",
-                "@babel/parser": "^7.28.3",
+                "@babel/parser": "^7.28.4",
                 "@babel/template": "^7.27.2",
-                "@babel/types": "^7.28.2",
+                "@babel/types": "^7.28.4",
                 "debug": "^4.3.1"
             },
             "engines": {
@@ -531,9 +517,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.28.2",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
-            "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+            "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -649,16 +635,16 @@
             }
         },
         "node_modules/@jest/core": {
-            "version": "30.1.2",
-            "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.1.2.tgz",
-            "integrity": "sha512-iSLOojkYgM7Lw0FF5egecZh+CiLWe4xICM3WOMjFbewhbWn+ixEoPwY7oK9jSCnLLphMFAjussXp7CE3tHa5EA==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.1.3.tgz",
+            "integrity": "sha512-LIQz7NEDDO1+eyOA2ZmkiAyYvZuo6s1UxD/e2IHldR6D7UYogVq3arTmli07MkENLq6/3JEQjp0mA8rrHHJ8KQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jest/console": "30.1.2",
                 "@jest/pattern": "30.0.1",
-                "@jest/reporters": "30.1.2",
-                "@jest/test-result": "30.1.2",
+                "@jest/reporters": "30.1.3",
+                "@jest/test-result": "30.1.3",
                 "@jest/transform": "30.1.2",
                 "@jest/types": "30.0.5",
                 "@types/node": "*",
@@ -668,18 +654,18 @@
                 "exit-x": "^0.2.2",
                 "graceful-fs": "^4.2.11",
                 "jest-changed-files": "30.0.5",
-                "jest-config": "30.1.2",
+                "jest-config": "30.1.3",
                 "jest-haste-map": "30.1.0",
                 "jest-message-util": "30.1.0",
                 "jest-regex-util": "30.0.1",
-                "jest-resolve": "30.1.0",
-                "jest-resolve-dependencies": "30.1.2",
-                "jest-runner": "30.1.2",
-                "jest-runtime": "30.1.2",
+                "jest-resolve": "30.1.3",
+                "jest-resolve-dependencies": "30.1.3",
+                "jest-runner": "30.1.3",
+                "jest-runtime": "30.1.3",
                 "jest-snapshot": "30.1.2",
                 "jest-util": "30.0.5",
                 "jest-validate": "30.1.0",
-                "jest-watcher": "30.1.2",
+                "jest-watcher": "30.1.3",
                 "micromatch": "^4.0.8",
                 "pretty-format": "30.0.5",
                 "slash": "^3.0.0"
@@ -808,15 +794,15 @@
             }
         },
         "node_modules/@jest/reporters": {
-            "version": "30.1.2",
-            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.1.2.tgz",
-            "integrity": "sha512-8Jd7y3DUFBn8dG/bNJ2blmaJmT2Up74WAXkUJsbL0OuEZHDRRMnS4JmRtLArW2d0H5k8RDdhNN7j70Ki16Zr5g==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.1.3.tgz",
+            "integrity": "sha512-VWEQmJWfXMOrzdFEOyGjUEOuVXllgZsoPtEHZzfdNz18RmzJ5nlR6kp8hDdY8dDS1yGOXAY7DHT+AOHIPSBV0w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@bcoe/v8-coverage": "^0.2.3",
                 "@jest/console": "30.1.2",
-                "@jest/test-result": "30.1.2",
+                "@jest/test-result": "30.1.3",
                 "@jest/transform": "30.1.2",
                 "@jest/types": "30.0.5",
                 "@jridgewell/trace-mapping": "^0.3.25",
@@ -895,9 +881,9 @@
             }
         },
         "node_modules/@jest/test-result": {
-            "version": "30.1.2",
-            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.1.2.tgz",
-            "integrity": "sha512-mpKFr8DEpfG5aAfQYA5+3KneAsRBXhF7zwtwqT4UeYBckoOPD1MzVxU6gDHwx4gRB7I1MKL6owyJzr8QRq402Q==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.1.3.tgz",
+            "integrity": "sha512-P9IV8T24D43cNRANPPokn7tZh0FAFnYS2HIfi5vK18CjRkTDR9Y3e1BoEcAJnl4ghZZF4Ecda4M/k41QkvurEQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -911,13 +897,13 @@
             }
         },
         "node_modules/@jest/test-sequencer": {
-            "version": "30.1.2",
-            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.1.2.tgz",
-            "integrity": "sha512-v3vawuj2LC0XjpzF4q0pI0ZlQvMBDNqfRZZ2yHqcsGt7JEYsDK2L1WwrybEGlnOaEvnDFML/Y9xWLiW47Dda8A==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.1.3.tgz",
+            "integrity": "sha512-82J+hzC0qeQIiiZDThh+YUadvshdBswi5nuyXlEmXzrhw5ZQSRHeQ5LpVMD/xc8B3wPePvs6VMzHnntxL+4E3w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/test-result": "30.1.2",
+                "@jest/test-result": "30.1.3",
                 "graceful-fs": "^4.2.11",
                 "jest-haste-map": "30.1.0",
                 "slash": "^3.0.0"
@@ -980,6 +966,17 @@
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/remapping": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.24"
             }
         },
@@ -1191,9 +1188,9 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "24.3.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-            "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+            "version": "24.3.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+            "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1566,9 +1563,9 @@
             }
         },
         "node_modules/ansi-regex": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
-            "integrity": "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1672,11 +1669,14 @@
             }
         },
         "node_modules/babel-plugin-istanbul": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.0.tgz",
-            "integrity": "sha512-C5OzENSx/A+gt7t4VH1I2XsflxyPUmXRFPKBxt33xncdOmq7oROVM3bZv9Ysjjkv8OJYDMa+tKuKMvqU/H3xdw==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+            "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "workspaces": [
+                "test/babel-8"
+            ],
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "@istanbuljs/load-nyc-config": "^1.0.0",
@@ -2011,9 +2011,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001739",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001739.tgz",
-            "integrity": "sha512-y+j60d6ulelrNSwpPyrHdl+9mJnQzHBr08xm48Qno0nSk4h3Qojh+ziv2qE6rXf4k3tadF4o1J/1tAbVm1NtnA==",
+            "version": "1.0.30001741",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
+            "integrity": "sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==",
             "dev": true,
             "funding": [
                 {
@@ -2319,9 +2319,9 @@
             }
         },
         "node_modules/dedent": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
-            "integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
+            "integrity": "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
@@ -2417,9 +2417,9 @@
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.211",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.211.tgz",
-            "integrity": "sha512-IGBvimJkotaLzFnwIVgW9/UD/AOJ2tByUmeOrtqBfACSbAw5b1G0XpvdaieKyc7ULmbwXVx+4e4Be8pOPBrYkw==",
+            "version": "1.5.214",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.214.tgz",
+            "integrity": "sha512-TpvUNdha+X3ybfU78NoQatKvQEm1oq3lf2QbnmCEdw+Bd9RuIAY+hJTvq1avzHM0f7EJfnH3vbCnbzKzisc/9Q==",
             "dev": true,
             "license": "ISC"
         },
@@ -3372,16 +3372,16 @@
             }
         },
         "node_modules/jest": {
-            "version": "30.1.2",
-            "resolved": "https://registry.npmjs.org/jest/-/jest-30.1.2.tgz",
-            "integrity": "sha512-iLreJmUWdANLD2UIbebrXxQqU9jIxv2ahvrBNfff55deL9DtVxm8ZJBLk/kmn0AQ+FyCTrNSlGbMdTgSasldYA==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-30.1.3.tgz",
+            "integrity": "sha512-Ry+p2+NLk6u8Agh5yVqELfUJvRfV51hhVBRIB5yZPY7mU0DGBmOuFG5GebZbMbm86cdQNK0fhJuDX8/1YorISQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/core": "30.1.2",
+                "@jest/core": "30.1.3",
                 "@jest/types": "30.0.5",
                 "import-local": "^3.2.0",
-                "jest-cli": "30.1.2"
+                "jest-cli": "30.1.3"
             },
             "bin": {
                 "jest": "bin/jest.js"
@@ -3414,15 +3414,15 @@
             }
         },
         "node_modules/jest-circus": {
-            "version": "30.1.2",
-            "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.1.2.tgz",
-            "integrity": "sha512-pyqgRv00fPbU3QBjN9I5QRd77eCWA19NA7BLgI1veFvbUIFpeDCKbnG1oyRr6q5/jPEW2zDfqZ/r6fvfE85vrA==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.1.3.tgz",
+            "integrity": "sha512-Yf3dnhRON2GJT4RYzM89t/EXIWNxKTpWTL9BfF3+geFetWP4XSvJjiU1vrWplOiUkmq8cHLiwuhz+XuUp9DscA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jest/environment": "30.1.2",
                 "@jest/expect": "30.1.2",
-                "@jest/test-result": "30.1.2",
+                "@jest/test-result": "30.1.3",
                 "@jest/types": "30.0.5",
                 "@types/node": "*",
                 "chalk": "^4.1.2",
@@ -3432,7 +3432,7 @@
                 "jest-each": "30.1.0",
                 "jest-matcher-utils": "30.1.2",
                 "jest-message-util": "30.1.0",
-                "jest-runtime": "30.1.2",
+                "jest-runtime": "30.1.3",
                 "jest-snapshot": "30.1.2",
                 "jest-util": "30.0.5",
                 "p-limit": "^3.1.0",
@@ -3446,19 +3446,19 @@
             }
         },
         "node_modules/jest-cli": {
-            "version": "30.1.2",
-            "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.1.2.tgz",
-            "integrity": "sha512-Q7H6GGo/0TBB8Mhm3Ab7KKJHn6GeMVff+/8PVCQ7vXXahvr5sRERnNbxuVJAMiVY2JQm5roA7CHYOYlH+gzmUg==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.1.3.tgz",
+            "integrity": "sha512-G8E2Ol3OKch1DEeIBl41NP7OiC6LBhfg25Btv+idcusmoUSpqUkbrneMqbW9lVpI/rCKb/uETidb7DNteheuAQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/core": "30.1.2",
-                "@jest/test-result": "30.1.2",
+                "@jest/core": "30.1.3",
+                "@jest/test-result": "30.1.3",
                 "@jest/types": "30.0.5",
                 "chalk": "^4.1.2",
                 "exit-x": "^0.2.2",
                 "import-local": "^3.2.0",
-                "jest-config": "30.1.2",
+                "jest-config": "30.1.3",
                 "jest-util": "30.0.5",
                 "jest-validate": "30.1.0",
                 "yargs": "^17.7.2"
@@ -3479,16 +3479,16 @@
             }
         },
         "node_modules/jest-config": {
-            "version": "30.1.2",
-            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.1.2.tgz",
-            "integrity": "sha512-gCuBeE/cksjQ3e1a8H4YglZJuVPcnLZQK9jC70E6GbkHNQKPasnOO+r9IYdsUbAekb6c7eVRR8laGLMF06gMqg==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.1.3.tgz",
+            "integrity": "sha512-M/f7gqdQEPgZNA181Myz+GXCe8jXcJsGjCMXUzRj22FIXsZOyHNte84e0exntOvdPaeh9tA0w+B8qlP2fAezfw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.27.4",
                 "@jest/get-type": "30.1.0",
                 "@jest/pattern": "30.0.1",
-                "@jest/test-sequencer": "30.1.2",
+                "@jest/test-sequencer": "30.1.3",
                 "@jest/types": "30.0.5",
                 "babel-jest": "30.1.2",
                 "chalk": "^4.1.2",
@@ -3496,12 +3496,12 @@
                 "deepmerge": "^4.3.1",
                 "glob": "^10.3.10",
                 "graceful-fs": "^4.2.11",
-                "jest-circus": "30.1.2",
+                "jest-circus": "30.1.3",
                 "jest-docblock": "30.0.1",
                 "jest-environment-node": "30.1.2",
                 "jest-regex-util": "30.0.1",
-                "jest-resolve": "30.1.0",
-                "jest-runner": "30.1.2",
+                "jest-resolve": "30.1.3",
+                "jest-runner": "30.1.3",
                 "jest-util": "30.0.5",
                 "jest-validate": "30.1.0",
                 "micromatch": "^4.0.8",
@@ -3715,9 +3715,9 @@
             }
         },
         "node_modules/jest-resolve": {
-            "version": "30.1.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.1.0.tgz",
-            "integrity": "sha512-hASe7D/wRtZw8Cm607NrlF7fi3HWC5wmA5jCVc2QjQAB2pTwP9eVZILGEi6OeSLNUtE1zb04sXRowsdh5CUjwA==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.1.3.tgz",
+            "integrity": "sha512-DI4PtTqzw9GwELFS41sdMK32Ajp3XZQ8iygeDMWkxlRhm7uUTOFSZFVZABFuxr0jvspn8MAYy54NxZCsuCTSOw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3735,9 +3735,9 @@
             }
         },
         "node_modules/jest-resolve-dependencies": {
-            "version": "30.1.2",
-            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.1.2.tgz",
-            "integrity": "sha512-HJjyoaedY4wrwda+eqvgjbwFykrAnQEmhuT0bMyOV3GQIyLPcunZcjfkm77Zr11ujwl34ySdc4qYnm7SG75TjA==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.1.3.tgz",
+            "integrity": "sha512-DNfq3WGmuRyHRHfEet+Zm3QOmVFtIarUOQHHryKPc0YL9ROfgWZxl4+aZq/VAzok2SS3gZdniP+dO4zgo59hBg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3749,15 +3749,15 @@
             }
         },
         "node_modules/jest-runner": {
-            "version": "30.1.2",
-            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.1.2.tgz",
-            "integrity": "sha512-eu9AzpDY/QV+7NuMg6fZMpQ7M24cBkl5dyS1Xj7iwDPDriOmLUXR8rLojESibcIX+sCDTO4KvUeaxWCH1fbTvg==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.1.3.tgz",
+            "integrity": "sha512-dd1ORcxQraW44Uz029TtXj85W11yvLpDuIzNOlofrC8GN+SgDlgY4BvyxJiVeuabA1t6idjNbX59jLd2oplOGQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jest/console": "30.1.2",
                 "@jest/environment": "30.1.2",
-                "@jest/test-result": "30.1.2",
+                "@jest/test-result": "30.1.3",
                 "@jest/transform": "30.1.2",
                 "@jest/types": "30.0.5",
                 "@types/node": "*",
@@ -3770,10 +3770,10 @@
                 "jest-haste-map": "30.1.0",
                 "jest-leak-detector": "30.1.0",
                 "jest-message-util": "30.1.0",
-                "jest-resolve": "30.1.0",
-                "jest-runtime": "30.1.2",
+                "jest-resolve": "30.1.3",
+                "jest-runtime": "30.1.3",
                 "jest-util": "30.0.5",
-                "jest-watcher": "30.1.2",
+                "jest-watcher": "30.1.3",
                 "jest-worker": "30.1.0",
                 "p-limit": "^3.1.0",
                 "source-map-support": "0.5.13"
@@ -3783,9 +3783,9 @@
             }
         },
         "node_modules/jest-runtime": {
-            "version": "30.1.2",
-            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.1.2.tgz",
-            "integrity": "sha512-zU02si+lAITgyRmVRgJn/AB4cnakq8+o7bP+5Z+N1A4r2mq40zGbmrg3UpYQWCkeim17tx8w1Tnmt6tQ6y9PGA==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.1.3.tgz",
+            "integrity": "sha512-WS8xgjuNSphdIGnleQcJ3AKE4tBKOVP+tKhCD0u+Tb2sBmsU8DxfbBpZX7//+XOz81zVs4eFpJQwBNji2Y07DA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3793,7 +3793,7 @@
                 "@jest/fake-timers": "30.1.2",
                 "@jest/globals": "30.1.2",
                 "@jest/source-map": "30.0.1",
-                "@jest/test-result": "30.1.2",
+                "@jest/test-result": "30.1.3",
                 "@jest/transform": "30.1.2",
                 "@jest/types": "30.0.5",
                 "@types/node": "*",
@@ -3806,7 +3806,7 @@
                 "jest-message-util": "30.1.0",
                 "jest-mock": "30.0.5",
                 "jest-regex-util": "30.0.1",
-                "jest-resolve": "30.1.0",
+                "jest-resolve": "30.1.3",
                 "jest-snapshot": "30.1.2",
                 "jest-util": "30.0.5",
                 "slash": "^3.0.0",
@@ -3912,13 +3912,13 @@
             }
         },
         "node_modules/jest-watcher": {
-            "version": "30.1.2",
-            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.1.2.tgz",
-            "integrity": "sha512-MtoGuEgqsBM8Jkn52oEj+mXLtF94+njPlHI5ydfduZL5MHrTFr14ZG1CUX1xAbY23dbSZCCEkEPhBM3cQd12Jg==",
+            "version": "30.1.3",
+            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.1.3.tgz",
+            "integrity": "sha512-6jQUZCP1BTL2gvG9E4YF06Ytq4yMb4If6YoQGRR6PpjtqOXSP3sKe2kqwB6SQ+H9DezOfZaSLnmka1NtGm3fCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/test-result": "30.1.2",
+                "@jest/test-result": "30.1.3",
                 "@jest/types": "30.0.5",
                 "@types/node": "*",
                 "ansi-escapes": "^4.3.2",
@@ -4539,9 +4539,9 @@
             "license": "MIT"
         },
         "node_modules/node-releases": {
-            "version": "2.0.19",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-            "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+            "version": "2.0.20",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.20.tgz",
+            "integrity": "sha512-7gK6zSXEH6neM212JgfYFXe+GmZQM+fia5SsusuBIUgnPheLFBmIPhtFoAQRj8/7wASYQnbDlHPVwY0BefoFgA==",
             "dev": true,
             "license": "MIT"
         },
@@ -5382,9 +5382,9 @@
             }
         },
         "node_modules/strip-ansi": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+            "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5935,9 +5935,9 @@
             }
         },
         "node_modules/wrap-ansi/node_modules/ansi-styles": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-            "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/users/authservice/package.json
+++ b/users/authservice/package.json
@@ -25,7 +25,7 @@
         "mongoose": "^8.18.0"
     },
     "devDependencies": {
-        "jest": "^30.1.2",
+        "jest": "^30.1.3",
         "mongodb-memory-server": "^10.2.0",
         "supertest": "^7.1.4"
     }

--- a/users/userservice/package-lock.json
+++ b/users/userservice/package-lock.json
@@ -15,23 +15,9 @@
         "mongoose": "^8.18.0"
       },
       "devDependencies": {
-        "jest": "^30.1.2",
+        "jest": "^30.1.3",
         "mongodb-memory-server": "^10.2.0",
         "supertest": "^7.1.4"
-      }
-    },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -50,9 +36,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
-      "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
+      "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -60,22 +46,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
-      "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
+      "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
         "@babel/helper-compilation-targets": "^7.27.2",
         "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.3",
-        "@babel/parser": "^7.28.3",
+        "@babel/helpers": "^7.28.4",
+        "@babel/parser": "^7.28.4",
         "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.3",
-        "@babel/types": "^7.28.2",
+        "@babel/traverse": "^7.28.4",
+        "@babel/types": "^7.28.4",
+        "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -232,27 +218,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.3.tgz",
-      "integrity": "sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.2"
+        "@babel/types": "^7.28.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
-      "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.2"
+        "@babel/types": "^7.28.4"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -516,18 +502,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.3.tgz",
-      "integrity": "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.3",
+        "@babel/parser": "^7.28.4",
         "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.2",
+        "@babel/types": "^7.28.4",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -560,9 +546,9 @@
       "license": "MIT"
     },
     "node_modules/@babel/types": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
-      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -688,16 +674,16 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.1.2.tgz",
-      "integrity": "sha512-iSLOojkYgM7Lw0FF5egecZh+CiLWe4xICM3WOMjFbewhbWn+ixEoPwY7oK9jSCnLLphMFAjussXp7CE3tHa5EA==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.1.3.tgz",
+      "integrity": "sha512-LIQz7NEDDO1+eyOA2ZmkiAyYvZuo6s1UxD/e2IHldR6D7UYogVq3arTmli07MkENLq6/3JEQjp0mA8rrHHJ8KQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "30.1.2",
         "@jest/pattern": "30.0.1",
-        "@jest/reporters": "30.1.2",
-        "@jest/test-result": "30.1.2",
+        "@jest/reporters": "30.1.3",
+        "@jest/test-result": "30.1.3",
         "@jest/transform": "30.1.2",
         "@jest/types": "30.0.5",
         "@types/node": "*",
@@ -707,18 +693,18 @@
         "exit-x": "^0.2.2",
         "graceful-fs": "^4.2.11",
         "jest-changed-files": "30.0.5",
-        "jest-config": "30.1.2",
+        "jest-config": "30.1.3",
         "jest-haste-map": "30.1.0",
         "jest-message-util": "30.1.0",
         "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.1.0",
-        "jest-resolve-dependencies": "30.1.2",
-        "jest-runner": "30.1.2",
-        "jest-runtime": "30.1.2",
+        "jest-resolve": "30.1.3",
+        "jest-resolve-dependencies": "30.1.3",
+        "jest-runner": "30.1.3",
+        "jest-runtime": "30.1.3",
         "jest-snapshot": "30.1.2",
         "jest-util": "30.0.5",
         "jest-validate": "30.1.0",
-        "jest-watcher": "30.1.2",
+        "jest-watcher": "30.1.3",
         "micromatch": "^4.0.8",
         "pretty-format": "30.0.5",
         "slash": "^3.0.0"
@@ -847,15 +833,15 @@
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.1.2.tgz",
-      "integrity": "sha512-8Jd7y3DUFBn8dG/bNJ2blmaJmT2Up74WAXkUJsbL0OuEZHDRRMnS4JmRtLArW2d0H5k8RDdhNN7j70Ki16Zr5g==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.1.3.tgz",
+      "integrity": "sha512-VWEQmJWfXMOrzdFEOyGjUEOuVXllgZsoPtEHZzfdNz18RmzJ5nlR6kp8hDdY8dDS1yGOXAY7DHT+AOHIPSBV0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
         "@jest/console": "30.1.2",
-        "@jest/test-result": "30.1.2",
+        "@jest/test-result": "30.1.3",
         "@jest/transform": "30.1.2",
         "@jest/types": "30.0.5",
         "@jridgewell/trace-mapping": "^0.3.25",
@@ -934,9 +920,9 @@
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.1.2.tgz",
-      "integrity": "sha512-mpKFr8DEpfG5aAfQYA5+3KneAsRBXhF7zwtwqT4UeYBckoOPD1MzVxU6gDHwx4gRB7I1MKL6owyJzr8QRq402Q==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.1.3.tgz",
+      "integrity": "sha512-P9IV8T24D43cNRANPPokn7tZh0FAFnYS2HIfi5vK18CjRkTDR9Y3e1BoEcAJnl4ghZZF4Ecda4M/k41QkvurEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -950,13 +936,13 @@
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.1.2.tgz",
-      "integrity": "sha512-v3vawuj2LC0XjpzF4q0pI0ZlQvMBDNqfRZZ2yHqcsGt7JEYsDK2L1WwrybEGlnOaEvnDFML/Y9xWLiW47Dda8A==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.1.3.tgz",
+      "integrity": "sha512-82J+hzC0qeQIiiZDThh+YUadvshdBswi5nuyXlEmXzrhw5ZQSRHeQ5LpVMD/xc8B3wPePvs6VMzHnntxL+4E3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "30.1.2",
+        "@jest/test-result": "30.1.3",
         "graceful-fs": "^4.2.11",
         "jest-haste-map": "30.1.0",
         "slash": "^3.0.0"
@@ -1019,6 +1005,17 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -1230,9 +1227,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1584,9 +1581,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
-      "integrity": "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1696,11 +1693,14 @@
       }
     },
     "node_modules/babel-plugin-istanbul": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.0.tgz",
-      "integrity": "sha512-C5OzENSx/A+gt7t4VH1I2XsflxyPUmXRFPKBxt33xncdOmq7oROVM3bZv9Ysjjkv8OJYDMa+tKuKMvqU/H3xdw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+      "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "workspaces": [
+        "test/babel-8"
+      ],
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@istanbuljs/load-nyc-config": "^1.0.0",
@@ -2055,9 +2055,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001739",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001739.tgz",
-      "integrity": "sha512-y+j60d6ulelrNSwpPyrHdl+9mJnQzHBr08xm48Qno0nSk4h3Qojh+ziv2qE6rXf4k3tadF4o1J/1tAbVm1NtnA==",
+      "version": "1.0.30001741",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
+      "integrity": "sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==",
       "dev": true,
       "funding": [
         {
@@ -2351,9 +2351,9 @@
       }
     },
     "node_modules/dedent": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
-      "integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
+      "integrity": "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2450,9 +2450,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.211",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.211.tgz",
-      "integrity": "sha512-IGBvimJkotaLzFnwIVgW9/UD/AOJ2tByUmeOrtqBfACSbAw5b1G0XpvdaieKyc7ULmbwXVx+4e4Be8pOPBrYkw==",
+      "version": "1.5.214",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.214.tgz",
+      "integrity": "sha512-TpvUNdha+X3ybfU78NoQatKvQEm1oq3lf2QbnmCEdw+Bd9RuIAY+hJTvq1avzHM0f7EJfnH3vbCnbzKzisc/9Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -3447,16 +3447,16 @@
       }
     },
     "node_modules/jest": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-30.1.2.tgz",
-      "integrity": "sha512-iLreJmUWdANLD2UIbebrXxQqU9jIxv2ahvrBNfff55deL9DtVxm8ZJBLk/kmn0AQ+FyCTrNSlGbMdTgSasldYA==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.1.3.tgz",
+      "integrity": "sha512-Ry+p2+NLk6u8Agh5yVqELfUJvRfV51hhVBRIB5yZPY7mU0DGBmOuFG5GebZbMbm86cdQNK0fhJuDX8/1YorISQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.1.2",
+        "@jest/core": "30.1.3",
         "@jest/types": "30.0.5",
         "import-local": "^3.2.0",
-        "jest-cli": "30.1.2"
+        "jest-cli": "30.1.3"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -3505,15 +3505,15 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.1.2.tgz",
-      "integrity": "sha512-pyqgRv00fPbU3QBjN9I5QRd77eCWA19NA7BLgI1veFvbUIFpeDCKbnG1oyRr6q5/jPEW2zDfqZ/r6fvfE85vrA==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.1.3.tgz",
+      "integrity": "sha512-Yf3dnhRON2GJT4RYzM89t/EXIWNxKTpWTL9BfF3+geFetWP4XSvJjiU1vrWplOiUkmq8cHLiwuhz+XuUp9DscA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "30.1.2",
         "@jest/expect": "30.1.2",
-        "@jest/test-result": "30.1.2",
+        "@jest/test-result": "30.1.3",
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "chalk": "^4.1.2",
@@ -3523,7 +3523,7 @@
         "jest-each": "30.1.0",
         "jest-matcher-utils": "30.1.2",
         "jest-message-util": "30.1.0",
-        "jest-runtime": "30.1.2",
+        "jest-runtime": "30.1.3",
         "jest-snapshot": "30.1.2",
         "jest-util": "30.0.5",
         "p-limit": "^3.1.0",
@@ -3553,19 +3553,19 @@
       }
     },
     "node_modules/jest-cli": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.1.2.tgz",
-      "integrity": "sha512-Q7H6GGo/0TBB8Mhm3Ab7KKJHn6GeMVff+/8PVCQ7vXXahvr5sRERnNbxuVJAMiVY2JQm5roA7CHYOYlH+gzmUg==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.1.3.tgz",
+      "integrity": "sha512-G8E2Ol3OKch1DEeIBl41NP7OiC6LBhfg25Btv+idcusmoUSpqUkbrneMqbW9lVpI/rCKb/uETidb7DNteheuAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.1.2",
-        "@jest/test-result": "30.1.2",
+        "@jest/core": "30.1.3",
+        "@jest/test-result": "30.1.3",
         "@jest/types": "30.0.5",
         "chalk": "^4.1.2",
         "exit-x": "^0.2.2",
         "import-local": "^3.2.0",
-        "jest-config": "30.1.2",
+        "jest-config": "30.1.3",
         "jest-util": "30.0.5",
         "jest-validate": "30.1.0",
         "yargs": "^17.7.2"
@@ -3586,16 +3586,16 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.1.2.tgz",
-      "integrity": "sha512-gCuBeE/cksjQ3e1a8H4YglZJuVPcnLZQK9jC70E6GbkHNQKPasnOO+r9IYdsUbAekb6c7eVRR8laGLMF06gMqg==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.1.3.tgz",
+      "integrity": "sha512-M/f7gqdQEPgZNA181Myz+GXCe8jXcJsGjCMXUzRj22FIXsZOyHNte84e0exntOvdPaeh9tA0w+B8qlP2fAezfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/get-type": "30.1.0",
         "@jest/pattern": "30.0.1",
-        "@jest/test-sequencer": "30.1.2",
+        "@jest/test-sequencer": "30.1.3",
         "@jest/types": "30.0.5",
         "babel-jest": "30.1.2",
         "chalk": "^4.1.2",
@@ -3603,12 +3603,12 @@
         "deepmerge": "^4.3.1",
         "glob": "^10.3.10",
         "graceful-fs": "^4.2.11",
-        "jest-circus": "30.1.2",
+        "jest-circus": "30.1.3",
         "jest-docblock": "30.0.1",
         "jest-environment-node": "30.1.2",
         "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.1.0",
-        "jest-runner": "30.1.2",
+        "jest-resolve": "30.1.3",
+        "jest-runner": "30.1.3",
         "jest-util": "30.0.5",
         "jest-validate": "30.1.0",
         "micromatch": "^4.0.8",
@@ -3822,9 +3822,9 @@
       }
     },
     "node_modules/jest-resolve": {
-      "version": "30.1.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.1.0.tgz",
-      "integrity": "sha512-hASe7D/wRtZw8Cm607NrlF7fi3HWC5wmA5jCVc2QjQAB2pTwP9eVZILGEi6OeSLNUtE1zb04sXRowsdh5CUjwA==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.1.3.tgz",
+      "integrity": "sha512-DI4PtTqzw9GwELFS41sdMK32Ajp3XZQ8iygeDMWkxlRhm7uUTOFSZFVZABFuxr0jvspn8MAYy54NxZCsuCTSOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3842,9 +3842,9 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.1.2.tgz",
-      "integrity": "sha512-HJjyoaedY4wrwda+eqvgjbwFykrAnQEmhuT0bMyOV3GQIyLPcunZcjfkm77Zr11ujwl34ySdc4qYnm7SG75TjA==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.1.3.tgz",
+      "integrity": "sha512-DNfq3WGmuRyHRHfEet+Zm3QOmVFtIarUOQHHryKPc0YL9ROfgWZxl4+aZq/VAzok2SS3gZdniP+dO4zgo59hBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3856,15 +3856,15 @@
       }
     },
     "node_modules/jest-runner": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.1.2.tgz",
-      "integrity": "sha512-eu9AzpDY/QV+7NuMg6fZMpQ7M24cBkl5dyS1Xj7iwDPDriOmLUXR8rLojESibcIX+sCDTO4KvUeaxWCH1fbTvg==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.1.3.tgz",
+      "integrity": "sha512-dd1ORcxQraW44Uz029TtXj85W11yvLpDuIzNOlofrC8GN+SgDlgY4BvyxJiVeuabA1t6idjNbX59jLd2oplOGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "30.1.2",
         "@jest/environment": "30.1.2",
-        "@jest/test-result": "30.1.2",
+        "@jest/test-result": "30.1.3",
         "@jest/transform": "30.1.2",
         "@jest/types": "30.0.5",
         "@types/node": "*",
@@ -3877,10 +3877,10 @@
         "jest-haste-map": "30.1.0",
         "jest-leak-detector": "30.1.0",
         "jest-message-util": "30.1.0",
-        "jest-resolve": "30.1.0",
-        "jest-runtime": "30.1.2",
+        "jest-resolve": "30.1.3",
+        "jest-runtime": "30.1.3",
         "jest-util": "30.0.5",
-        "jest-watcher": "30.1.2",
+        "jest-watcher": "30.1.3",
         "jest-worker": "30.1.0",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
@@ -3906,9 +3906,9 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.1.2.tgz",
-      "integrity": "sha512-zU02si+lAITgyRmVRgJn/AB4cnakq8+o7bP+5Z+N1A4r2mq40zGbmrg3UpYQWCkeim17tx8w1Tnmt6tQ6y9PGA==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.1.3.tgz",
+      "integrity": "sha512-WS8xgjuNSphdIGnleQcJ3AKE4tBKOVP+tKhCD0u+Tb2sBmsU8DxfbBpZX7//+XOz81zVs4eFpJQwBNji2Y07DA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3916,7 +3916,7 @@
         "@jest/fake-timers": "30.1.2",
         "@jest/globals": "30.1.2",
         "@jest/source-map": "30.0.1",
-        "@jest/test-result": "30.1.2",
+        "@jest/test-result": "30.1.3",
         "@jest/transform": "30.1.2",
         "@jest/types": "30.0.5",
         "@types/node": "*",
@@ -3929,7 +3929,7 @@
         "jest-message-util": "30.1.0",
         "jest-mock": "30.0.5",
         "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.1.0",
+        "jest-resolve": "30.1.3",
         "jest-snapshot": "30.1.2",
         "jest-util": "30.0.5",
         "slash": "^3.0.0",
@@ -4035,13 +4035,13 @@
       }
     },
     "node_modules/jest-watcher": {
-      "version": "30.1.2",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.1.2.tgz",
-      "integrity": "sha512-MtoGuEgqsBM8Jkn52oEj+mXLtF94+njPlHI5ydfduZL5MHrTFr14ZG1CUX1xAbY23dbSZCCEkEPhBM3cQd12Jg==",
+      "version": "30.1.3",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.1.3.tgz",
+      "integrity": "sha512-6jQUZCP1BTL2gvG9E4YF06Ytq4yMb4If6YoQGRR6PpjtqOXSP3sKe2kqwB6SQ+H9DezOfZaSLnmka1NtGm3fCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "30.1.2",
+        "@jest/test-result": "30.1.3",
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",
@@ -4667,9 +4667,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.20.tgz",
+      "integrity": "sha512-7gK6zSXEH6neM212JgfYFXe+GmZQM+fia5SsusuBIUgnPheLFBmIPhtFoAQRj8/7wASYQnbDlHPVwY0BefoFgA==",
       "dev": true,
       "license": "MIT"
     },
@@ -5486,9 +5486,9 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6084,9 +6084,9 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/users/userservice/package.json
+++ b/users/userservice/package.json
@@ -25,7 +25,7 @@
     "mongoose": "^8.18.0"
   },
   "devDependencies": {
-    "jest": "^30.1.2",
+    "jest": "^30.1.3",
     "mongodb-memory-server": "^10.2.0",
     "supertest": "^7.1.4"
   }

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.11.0",
-        "@mui/material": "^5.15.15",
+        "@mui/material": "^7.3.2",
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -1969,12 +1969,10 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
-      "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2593,44 +2591,6 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
-    },
-    "node_modules/@floating-ui/core": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.10"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
-      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/core": "^1.7.3",
-        "@floating-ui/utils": "^0.2.10"
-      }
-    },
-    "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
-      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.7.4"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
-      "license": "MIT"
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
@@ -4561,34 +4521,36 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "5.15.15",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.15.tgz",
-      "integrity": "sha512-aXnw29OWQ6I5A47iuWEI6qSSUfH6G/aCsW9KmW3LiFqr7uXZBK4Ks+z8G+qeIub8k0T5CMqlT2q0L+ZJTMrqpg==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.2.tgz",
+      "integrity": "sha512-AOyfHjyDKVPGJJFtxOlept3EYEdLoar/RvssBTWVAvDJGIE676dLi2oT/Kx+FoVXFoA/JdV7DEMq/BVWV3KHRw==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
       }
     },
     "node_modules/@mui/material": {
-      "version": "5.15.15",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.15.15.tgz",
-      "integrity": "sha512-3zvWayJ+E1kzoIsvwyEvkTUKVKt1AjchFFns+JtluHCuvxgKcLSRJTADw37k0doaRtVAsyh8bz9Afqzv+KYrIA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.2.tgz",
+      "integrity": "sha512-qXvbnawQhqUVfH1LMgMaiytP+ZpGoYhnGl7yYq2x57GYzcFL/iPzSZ3L30tlbwEjSVKNYcbiKO8tANR1tadjUg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/base": "5.0.0-beta.40",
-        "@mui/core-downloads-tracker": "^5.15.15",
-        "@mui/system": "^5.15.15",
-        "@mui/types": "^7.2.14",
-        "@mui/utils": "^5.15.14",
-        "@types/react-transition-group": "^4.4.10",
-        "clsx": "^2.1.0",
+        "@babel/runtime": "^7.28.3",
+        "@mui/core-downloads-tracker": "^7.3.2",
+        "@mui/system": "^7.3.2",
+        "@mui/types": "^7.4.6",
+        "@mui/utils": "^7.3.2",
+        "@popperjs/core": "^2.11.8",
+        "@types/react-transition-group": "^4.4.12",
+        "clsx": "^2.1.1",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1",
-        "react-is": "^18.2.0",
+        "react-is": "^19.1.1",
         "react-transition-group": "^4.4.5"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4597,9 +4559,10 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "@mui/material-pigment-css": "^7.3.2",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@emotion/react": {
@@ -4608,68 +4571,40 @@
         "@emotion/styled": {
           "optional": true
         },
-        "@types/react": {
+        "@mui/material-pigment-css": {
           "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/material/node_modules/@mui/base": {
-      "version": "5.0.0-beta.40",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.40.tgz",
-      "integrity": "sha512-I/lGHztkCzvwlXpjD2+SNmvNQvB4227xBXhISPjEaJUXGImOQ9f3D2Yj/T3KasSI/h0MLWy74X0J6clhPmsRbQ==",
-      "deprecated": "This package has been replaced by @base-ui-components/react",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@floating-ui/react-dom": "^2.0.8",
-        "@mui/types": "^7.2.14",
-        "@mui/utils": "^5.15.14",
-        "@popperjs/core": "^2.11.8",
-        "clsx": "^2.1.0",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
+        },
         "@types/react": {
           "optional": true
         }
       }
     },
     "node_modules/@mui/material/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
+      "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
+      "license": "MIT"
     },
     "node_modules/@mui/private-theming": {
-      "version": "5.15.14",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.15.14.tgz",
-      "integrity": "sha512-UH0EiZckOWcxiXLX3Jbb0K7rC8mxTr9L9l6QhOZxYc4r8FHUkefltV9VDGLrzCaWh30SQiJvAEd7djX3XXY6Xw==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.2.tgz",
+      "integrity": "sha512-ha7mFoOyZGJr75xeiO9lugS3joRROjc8tG1u4P50dH0KR7bwhHznVMcYg7MouochUy0OxooJm/OOSpJ7gKcMvg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/utils": "^5.15.14",
+        "@babel/runtime": "^7.28.3",
+        "@mui/utils": "^7.3.2",
         "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -4678,17 +4613,20 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "5.15.14",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.15.14.tgz",
-      "integrity": "sha512-RILkuVD8gY6PvjZjqnWhz8fu68dVkqhM5+jYWfB5yhlSQKg+2rHkmEwm75XIeAqI3qwOndK6zELK5H6Zxn4NHw==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.2.tgz",
+      "integrity": "sha512-PkJzW+mTaek4e0nPYZ6qLnW5RGa0KN+eRTf5FA2nc7cFZTeM+qebmGibaTLrgQBy3UpcpemaqfzToBNkzuxqew==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@emotion/cache": "^11.11.0",
+        "@babel/runtime": "^7.28.3",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4697,7 +4635,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.4.1",
         "@emotion/styled": "^11.3.0",
-        "react": "^17.0.0 || ^18.0.0"
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@emotion/react": {
@@ -4709,21 +4647,22 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "5.15.15",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.15.15.tgz",
-      "integrity": "sha512-aulox6N1dnu5PABsfxVGOZffDVmlxPOVgj56HrUnJE8MCSh8lOvvkd47cebIVQQYAjpwieXQXiDPj5pwM40jTQ==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.2.tgz",
+      "integrity": "sha512-9d8JEvZW+H6cVkaZ+FK56R53vkJe3HsTpcjMUtH8v1xK6Y1TjzHdZ7Jck02mGXJsE6MQGWVs3ogRHTQmS9Q/rA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@mui/private-theming": "^5.15.14",
-        "@mui/styled-engine": "^5.15.14",
-        "@mui/types": "^7.2.14",
-        "@mui/utils": "^5.15.14",
-        "clsx": "^2.1.0",
+        "@babel/runtime": "^7.28.3",
+        "@mui/private-theming": "^7.3.2",
+        "@mui/styled-engine": "^7.3.2",
+        "@mui/types": "^7.4.6",
+        "@mui/utils": "^7.3.2",
+        "clsx": "^2.1.1",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4732,8 +4671,8 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@emotion/react": {
@@ -4748,11 +4687,15 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.2.14",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.14.tgz",
-      "integrity": "sha512-MZsBZ4q4HfzBsywtXgM1Ksj6HDThtiwmOKUXH1pKYISI9gAVXCNHNpo7TlGoGrBaYWZTdNoirIN7JsQcQUjmQQ==",
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.6.tgz",
+      "integrity": "sha512-NVBbIw+4CDMMppNamVxyTccNv0WxtDb7motWDlMeSC8Oy95saj1TIZMGynPpFLePt3yOD8TskzumeqORCgRGWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.3"
+      },
       "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0"
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -4761,25 +4704,28 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.15.14",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.15.14.tgz",
-      "integrity": "sha512-0lF/7Hh/ezDv5X7Pry6enMsbYyGKjADzvHyo3Qrc/SSlTsQ1VkbDMbH0m2t3OR5iIVLwMoxwM7yGd+6FCMtTFA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.2.tgz",
+      "integrity": "sha512-4DMWQGenOdLnM3y/SdFQFwKsCLM+mqxzvoWp9+x2XdEzXapkznauHLiXtSohHs/mc0+5/9UACt1GdugCX2te5g==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@types/prop-types": "^15.7.11",
+        "@babel/runtime": "^7.28.3",
+        "@mui/types": "^7.4.6",
+        "@types/prop-types": "^15.7.15",
+        "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
-        "react-is": "^18.2.0"
+        "react-is": "^19.1.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -4788,9 +4734,10 @@
       }
     },
     "node_modules/@mui/utils/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
+      "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
+      "license": "MIT"
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -5745,9 +5692,10 @@
       "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA=="
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.11",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
-      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "license": "MIT"
     },
     "node_modules/@types/q": {
       "version": "1.5.8",
@@ -5768,6 +5716,7 @@
       "version": "18.2.47",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.47.tgz",
       "integrity": "sha512-xquNkkOirwyCgoClNk85BjP+aqnIS+ckAJ8i37gAbDs14jfW/J23f2GItAf33oiUPQnqNMALiFeoM9Y5mbjpVQ==",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -5785,10 +5734,11 @@
       }
     },
     "node_modules/@types/react-transition-group": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
-      "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
-      "dependencies": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "license": "MIT",
+      "peerDependencies": {
         "@types/react": "*"
       }
     },
@@ -5808,7 +5758,8 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
+      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
+      "peer": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.6",
@@ -8097,9 +8048,10 @@
       }
     },
     "node_modules/clsx": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
-      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -23313,11 +23265,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -28,7 +28,7 @@
         "jest-environment-node": "^29.7.0",
         "mongodb-memory-server": "^10.2.0",
         "puppeteer": "^21.7.0",
-        "serve": "^14.2.1",
+        "serve": "^14.2.5",
         "start-server-and-test": "^2.0.13"
       }
     },
@@ -6279,10 +6279,11 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
     "node_modules/@zeit/schemas": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.29.0.tgz",
-      "integrity": "sha512-g5QiLIfbg3pLuYUJPlisNKY+epQJTcMDsOnVNkscrDP1oi7vmJnzOANYJI/1pZcVJ6umUkBv3aFtlg1UvUHGzA==",
-      "dev": true
+      "version": "2.36.0",
+      "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.36.0.tgz",
+      "integrity": "sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -7319,14 +7320,6 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/body-parser/node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/body-parser/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -7620,9 +7613,10 @@
       }
     },
     "node_modules/bytes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -8231,16 +8225,17 @@
       }
     },
     "node_modules/compression": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
-      "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
       "dependencies": {
-        "accepts": "~1.3.5",
-        "bytes": "3.0.0",
-        "compressible": "~2.0.16",
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
         "debug": "2.6.9",
-        "on-headers": "~1.0.2",
-        "safe-buffer": "5.1.2",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
         "vary": "~1.1.2"
       },
       "engines": {
@@ -8260,10 +8255,14 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
-    "node_modules/compression/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -10874,21 +10873,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
-    },
-    "node_modules/fast-url-parser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
-      "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
-      "dev": true,
-      "dependencies": {
-        "punycode": "^1.3.2"
-      }
-    },
-    "node_modules/fast-url-parser/node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "dev": true
     },
     "node_modules/fastq": {
       "version": "1.16.0",
@@ -19629,9 +19613,10 @@
       }
     },
     "node_modules/on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -19924,7 +19909,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==",
-      "dev": true
+      "dev": true,
+      "license": "(WTFPL OR MIT)"
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -21794,14 +21780,6 @@
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
       },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/raw-body/node_modules/bytes": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -24295,21 +24273,22 @@
       }
     },
     "node_modules/serve": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.1.tgz",
-      "integrity": "sha512-48er5fzHh7GCShLnNyPBRPEjs2I6QBozeGr02gaacROiyS/8ARADlj595j39iZXAqBbJHH/ivJJyPRWY9sQWZA==",
+      "version": "14.2.5",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.5.tgz",
+      "integrity": "sha512-Qn/qMkzCcMFVPb60E/hQy+iRLpiU8PamOfOSYoAHmmF+fFFmpPpqa6Oci2iWYpTdOUM3VF+TINud7CfbQnsZbA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@zeit/schemas": "2.29.0",
-        "ajv": "8.11.0",
+        "@zeit/schemas": "2.36.0",
+        "ajv": "8.12.0",
         "arg": "5.0.2",
         "boxen": "7.0.0",
         "chalk": "5.0.1",
         "chalk-template": "0.4.0",
         "clipboardy": "3.0.0",
-        "compression": "1.7.4",
+        "compression": "1.8.1",
         "is-port-reachable": "4.0.0",
-        "serve-handler": "6.1.5",
+        "serve-handler": "6.1.6",
         "update-check": "1.5.4"
       },
       "bin": {
@@ -24320,19 +24299,29 @@
       }
     },
     "node_modules/serve-handler": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.5.tgz",
-      "integrity": "sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.6.tgz",
+      "integrity": "sha512-x5RL9Y2p5+Sh3D38Fh9i/iQ5ZK+e4xuXRd/pGbM4D13tgo/MGwbttUk8emytcr1YYzBYs+apnUngBDFYfpjPuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bytes": "3.0.0",
         "content-disposition": "0.5.2",
-        "fast-url-parser": "1.1.3",
         "mime-types": "2.1.18",
         "minimatch": "3.1.2",
         "path-is-inside": "1.0.2",
-        "path-to-regexp": "2.2.1",
+        "path-to-regexp": "3.3.0",
         "range-parser": "1.2.0"
+      }
+    },
+    "node_modules/serve-handler/node_modules/bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/serve-handler/node_modules/content-disposition": {
@@ -24340,6 +24329,7 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
       "integrity": "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -24349,6 +24339,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
       "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -24358,6 +24349,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mime-db": "~1.33.0"
       },
@@ -24366,16 +24358,18 @@
       }
     },
     "node_modules/serve-handler/node_modules/path-to-regexp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
-      "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==",
-      "dev": true
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/serve-handler/node_modules/range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -24465,10 +24459,11 @@
       }
     },
     "node_modules/serve/node_modules/ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -24496,7 +24491,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -29,7 +29,7 @@
         "mongodb-memory-server": "^10.2.0",
         "puppeteer": "^21.7.0",
         "serve": "^14.2.5",
-        "start-server-and-test": "^2.0.13"
+        "start-server-and-test": "^2.1.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -25052,9 +25052,9 @@
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
     },
     "node_modules/start-server-and-test": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-2.0.13.tgz",
-      "integrity": "sha512-G42GCIUjBv/nDoK+QsO+nBdX2Cg3DSAKhSic2DN0GLlK4Q+63TkOeN1cV9PHZKnVOzDKGNVZGCREjpvAIAOdiQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-2.1.0.tgz",
+      "integrity": "sha512-yJg/GR9z7+8qxhZqDPmCEKbU/BO/zpyXUZGLmY1Nv4rmJJDC89NnzIEUWXEG4e1J4MRFoDF50eJK8bGHKrSdlg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -49,7 +49,7 @@
     "jest-environment-node": "^29.7.0",
     "mongodb-memory-server": "^10.2.0",
     "puppeteer": "^21.7.0",
-    "serve": "^14.2.1",
+    "serve": "^14.2.5",
     "start-server-and-test": "^2.0.13"
   }
 }

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -50,6 +50,6 @@
     "mongodb-memory-server": "^10.2.0",
     "puppeteer": "^21.7.0",
     "serve": "^14.2.5",
-    "start-server-and-test": "^2.0.13"
+    "start-server-and-test": "^2.1.0"
   }
 }

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.11.0",
-    "@mui/material": "^5.15.15",
+    "@mui/material": "^7.3.2",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump jest from 30.1.2 to 30.1.3 in /users/userservice](https://github.com/augustocristian/asw2324_0/pull/163)
- [Bump jest from 30.1.2 to 30.1.3 in /users/authservice](https://github.com/augustocristian/asw2324_0/pull/162)
- [Bump jest from 30.1.2 to 30.1.3 in /gatewayservice](https://github.com/augustocristian/asw2324_0/pull/161)
- [Bump serve from 14.2.1 to 14.2.5 in /webapp](https://github.com/augustocristian/asw2324_0/pull/160)
- [Bump start-server-and-test from 2.0.13 to 2.1.0 in /webapp](https://github.com/augustocristian/asw2324_0/pull/159)
- [Bump @mui/material from 5.15.15 to 7.3.2 in /webapp](https://github.com/augustocristian/asw2324_0/pull/158)

Does not include these updates because of merge conflicts:
- [Bump the npm_and_yarn group across 3 directories with 30 updates](https://github.com/augustocristian/asw2324_0/pull/157)