### PR TITLE
Combined dependency updates (2025-09-22)

### DIFF
--- a/gatewayservice/package-lock.json
+++ b/gatewayservice/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "axios": "^1.11.0",
+                "axios": "^1.12.2",
                 "cors": "^2.8.5",
                 "express": "^5.1.0",
                 "express-prom-bundle": "^7.0.0"
@@ -1652,9 +1652,9 @@
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "node_modules/axios": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-            "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+            "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.6",

--- a/gatewayservice/package.json
+++ b/gatewayservice/package.json
@@ -18,7 +18,7 @@
     },
     "homepage": "https://github.com/pglez82/asw2324_0#readme",
     "dependencies": {
-        "axios": "^1.11.0",
+        "axios": "^1.12.2",
         "cors": "^2.8.5",
         "express": "^5.1.0",
         "express-prom-bundle": "^7.0.0"

--- a/users/authservice/package-lock.json
+++ b/users/authservice/package-lock.json
@@ -13,7 +13,7 @@
                 "body-parser": "^2.2.0",
                 "express": "^5.1.0",
                 "jsonwebtoken": "^9.0.2",
-                "mongoose": "^8.18.0"
+                "mongoose": "^8.18.1"
             },
             "devDependencies": {
                 "jest": "^30.1.2",
@@ -4424,9 +4424,9 @@
             }
         },
         "node_modules/mongoose": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.18.0.tgz",
-            "integrity": "sha512-3TixPihQKBdyaYDeJqRjzgb86KbilEH07JmzV8SoSjgoskNTpa6oTBmDxeoF9p8YnWQoz7shnCyPkSV/48y3yw==",
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.18.1.tgz",
+            "integrity": "sha512-K0RfrUXXufqNRZZjvAGdyjydB91SnbWxlwFYi5t7zN2DxVWFD3c6puia0/7xfBwZm6RCpYOVdYFlRFpoDWiC+w==",
             "license": "MIT",
             "dependencies": {
                 "bson": "^6.10.4",

--- a/users/authservice/package.json
+++ b/users/authservice/package.json
@@ -22,7 +22,7 @@
         "body-parser": "^2.2.0",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
-        "mongoose": "^8.18.0"
+        "mongoose": "^8.18.1"
     },
     "devDependencies": {
         "jest": "^30.1.2",

--- a/users/userservice/package-lock.json
+++ b/users/userservice/package-lock.json
@@ -12,7 +12,7 @@
         "bcrypt": "^6.0.0",
         "body-parser": "^2.2.0",
         "express": "^5.1.0",
-        "mongoose": "^8.18.0"
+        "mongoose": "^8.18.1"
       },
       "devDependencies": {
         "jest": "^30.1.2",
@@ -4304,9 +4304,9 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.18.0.tgz",
-      "integrity": "sha512-3TixPihQKBdyaYDeJqRjzgb86KbilEH07JmzV8SoSjgoskNTpa6oTBmDxeoF9p8YnWQoz7shnCyPkSV/48y3yw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.18.1.tgz",
+      "integrity": "sha512-K0RfrUXXufqNRZZjvAGdyjydB91SnbWxlwFYi5t7zN2DxVWFD3c6puia0/7xfBwZm6RCpYOVdYFlRFpoDWiC+w==",
       "license": "MIT",
       "dependencies": {
         "bson": "^6.10.4",

--- a/users/userservice/package.json
+++ b/users/userservice/package.json
@@ -22,7 +22,7 @@
     "bcrypt": "^6.0.0",
     "body-parser": "^2.2.0",
     "express": "^5.1.0",
-    "mongoose": "^8.18.0"
+    "mongoose": "^8.18.1"
   },
   "devDependencies": {
     "jest": "^30.1.2",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -14,7 +14,7 @@
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
-        "axios": "^1.6.8",
+        "axios": "^1.12.2",
         "react": "^18.2.0",
         "react-dom": "^19.1.1",
         "react-scripts": "5.0.1",
@@ -6729,9 +6729,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -9,7 +9,7 @@
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
-    "axios": "^1.6.8",
+    "axios": "^1.12.2",
     "react": "^18.2.0",
     "react-dom": "^19.1.1",
     "react-scripts": "5.0.1",


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump axios from 1.11.0 to 1.12.2 in /gatewayservice](https://github.com/augustocristian/asw2324_0/pull/170)
- [Bump axios from 1.11.0 to 1.12.2 in /webapp](https://github.com/augustocristian/asw2324_0/pull/169)
- [Bump mongoose from 8.18.0 to 8.18.1 in /users/userservice](https://github.com/augustocristian/asw2324_0/pull/168)
- [Bump mongoose from 8.18.0 to 8.18.1 in /users/authservice](https://github.com/augustocristian/asw2324_0/pull/167)

Does not include these updates because of merge conflicts:
- [Bump axios from 1.11.0 to 1.12.0 in /gatewayservice in the npm_and_yarn group across 1 directory](https://github.com/augustocristian/asw2324_0/pull/166)
- [Bump the npm_and_yarn group across 1 directory with 3 updates](https://github.com/augustocristian/asw2324_0/pull/165)